### PR TITLE
feat(backend): add provider/model metrics for LLM A/B experiment

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -93,8 +93,16 @@ async def request_id_middleware(request: Request, call_next):
                     "METRIC|event=request",
                     f"path={path}",
                     f"method={request.method}",
-                    f"ms_total={duration_ms}",
                 ]
+
+                ## 추가: provider/model
+                if "provider" in m:
+                    parts.append(f"provider={m['provider']}")
+                if "model" in m:
+                    parts.append(f"model={m['model']}")
+
+                parts.append(f"ms_total={duration_ms}")
+                
                 # 라우터에서 기록한 값이 있으면 함께 출력
                 for key in (
                     "ms_db_user",

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -67,8 +67,19 @@ def chat(
         message=message,
         session_id=session_id,
     )
-    ms_ask_llm = span("ask_llm_total", t)
+
+    ## ask_llm_total에도 provider/model 태그를 달아준다.
+    provider = (extra or {}).get("provider")
+    model = (extra or {}).get("model")
+
+    ms_ask_llm = span("ask_llm_total", t, provider=provider, model=model)
     request.state.metrics["ms_ask_llm"] = ms_ask_llm  # ✅ 라우터 단위 메트릭 저장소에 기록
+
+    ## request 요약 로그에 실릴 수 있도록 저장
+    if provider:
+        request.state.metrics["provider"] = provider
+    if model:
+        request.state.metrics["model"] = model
 
     # history load도 요청 요약에 포함(2단계 요구)
     if extra and "ms_history_load" in extra:

--- a/backend/app/service/llm_service.py
+++ b/backend/app/service/llm_service.py
@@ -3,8 +3,9 @@ from functools import lru_cache
 from typing import Optional, Any
 
 # from requests import Session
-from sqlalchemy.orm import Session  # ✅ 기존 코드의 requests.Session은 오타/부정확 가능성 높음
+from sqlalchemy.orm import Session
 
+from app.core.config import OPENAI_MODEL
 from app.core.logger import get_logger
 from app.core.metrics import now, span
 from app.repository.chat import list_messages
@@ -47,8 +48,8 @@ def ask_llm(db: Session, message: str, session_id: Optional[str] = None):
         )
 
     chain = get_chain()
-
     result = chain({"input": input_text})  # invoke와 동일하게 동작
+
     answer = (result.get("answer") or "").strip()
     sources = result.get("sources") or []
 
@@ -59,5 +60,11 @@ def ask_llm(db: Session, message: str, session_id: Optional[str] = None):
         len(sources),
     )
 
-    extra: dict[str, Any] = {"ms_history_load": ms_history_load}
+    ## A/B를 위한 최소 메타
+    extra: dict[str, Any] = {
+        "ms_history_load": ms_history_load,
+        "provider": "openai",
+        "model": OPENAI_MODEL,
+    }
+
     return answer, session_id, sources, extra


### PR DESCRIPTION
## 📌 개요

LLM 성능 비교(A/B 테스트)를 위한 관측(Observability) 기반을 구축했습니다.

기존에는 LLM 실행 시간에 대한 측정은 있었지만,  
어떤 **Provider(OpenAI / Bedrock)** 및 어떤 **Model**이 사용되었는지 구분할 수 없었습니다.

이번 변경을 통해 provider 및 model 정보를 모든 핵심 METRIC 로그에 포함시켜,
CloudWatch에서 LLM 성능을 정확히 비교·분석할 수 있도록 구조를 개선했습니다.

---

## ✨ 주요 변경 사항

### Backend — LLM Metrics 구조 확장

#### 1️⃣ ask_llm_total span에 provider/model 태그 추가
- LLM 전체 실행 구간(`ask_llm_total`)에 provider 및 model 정보 포함
- 향후 OpenAI vs Bedrock 성능 비교 가능

예시:
METRIC|event=span|name=ask_llm_total|ms=...|provider=openai|model=gpt-4o-mini


---

#### 2️⃣ request-level METRIC 로그 확장
- `METRIC|event=request` 로그에 provider/model 정보 추가
- 요청 단위 성능 집계(p50/p95/p99) 시 provider 기준 필터링 가능

예시:
METRIC|event=request|path=/api/chat/...|provider=openai|model=gpt-4o-mini|ms_total=...


---

#### 3️⃣ A/B 테스트 준비 구조 정비
- provider/model 기준 집계가 가능하도록 로그 포맷 정규화
- 추후 Bedrock 도입 시 별도 로그 수정 없이 비교 가능
- CloudWatch Logs Insights에서 provider/model 기준 통계 집계 가능

---

## 🎯 변경 목적

- LLM Provider별 성능 비교 기반 마련
- OpenAI ↔ Bedrock A/B 테스트 준비
- LLM 구간과 RAG 구간의 성능 분리 분석 가능
- 운영 환경에서 p50/p95/p99 기반 의사결정 가능하도록 구조 개선

---

## 🧪 테스트 사항

- 로컬 환경에서 채팅 요청 4회 반복 테스트
- ask_llm_total span에 provider/model 정상 출력 확인
- request-level METRIC 로그에 provider/model 포함 확인
- 기존 응답 로직 및 기능 동작 이상 없음 확인

---

## ⚠️ 영향 범위

- 로깅 구조 확장 (비즈니스 로직 변경 없음)
- API 응답 포맷 변경 없음
- RAG 및 LLM 호출 흐름 변경 없음
- 기존 OpenAI-only 환경과 완전 호환

---

## 🚀 다음 단계

- Dev EB Role에 Bedrock InvokeModel 권한 추가
- LLM Provider 분기 로직 구현
- 50:50 A/B 테스트 실행
- CloudWatch 기반 provider별 성능 비교 분석

---

## ℹ️ 참고

본 PR은 **LLM A/B 실험을 위한 관측 구조 준비 단계**입니다.  
실제 Bedrock LLM 호출 및 Provider 분기 로직은 이후 PR에서 반영 예정입니다.