### PR TITLE
feat(backend): introduce Bedrock provider and session-based LLM A/B routing

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -71,3 +71,15 @@ DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./dev.db")
 
 
 METRICS_ENABLED = os.getenv("METRICS_ENABLED", "true").lower() == "true"
+
+
+# ======================================
+# provider config
+# ======================================
+LLM_PROVIDER_MODE = os.getenv("LLM_PROVIDER_MODE", "openai").lower()
+LLM_AB_RATIO = int(os.getenv("LLM_AB_RATIO", "50"))
+BEDROCK_REGION = os.getenv("BEDROCK_REGION", "us-east-1")
+BEDROCK_MODEL_ID = os.getenv(
+    "BEDROCK_MODEL_ID",
+    "anthropic.claude-3-haiku-20240307-v1:0",
+)

--- a/backend/app/service/chain_builder.py
+++ b/backend/app/service/chain_builder.py
@@ -4,22 +4,24 @@ import json
 from pathlib import Path
 from typing import List, Any, Dict, Tuple
 
+import boto3
 from langchain_openai import ChatOpenAI
+from langchain_aws import ChatBedrock
 from langchain_core.documents import Document
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
 from app.core.metrics import now, span, mark
-from app.core.config import OPENAI_MODEL, RAG_TOP_K
+from app.core.config import RAG_TOP_K, BEDROCK_REGION
 from app.core.logger import get_logger
 from app.service.retriever_service import get_retriever
 
 logger = get_logger("chatbot-law-prod.chain_builder")
 
 
-# -----------------------------------------------------------------------------
-# Keyword dictionary (optional)
-# -----------------------------------------------------------------------------
+## ==============================================================================
+## Keyword dictionary (optional)
+## ==============================================================================
 def load_keyword_dictionary() -> dict:
     data_path = Path(__file__).resolve().parents[1] / "data" / "keyword_dictionary.json"
 
@@ -162,10 +164,32 @@ def _format_docs_with_citation_numbers(
     return context_text, sources
 
 
-# -----------------------------------------------------------------------------
-# RAG Chain Builder (stateless)
-# -----------------------------------------------------------------------------
-def build_rag_chain():
+def _build_llm(provider: str, model_name: str):
+    if provider == "bedrock":
+        logger.info(
+            "Initializing Bedrock chat model. region=%s, model=%s",
+            BEDROCK_REGION,
+            model_name,
+        )
+
+        return ChatBedrock(
+            region_name=BEDROCK_REGION,
+            model_id=model_name,
+            model_kwargs={
+                "temperature": 0.3,
+                "max_tokens": 1024,
+            },
+        )
+    
+    logger.info("Initializing OpenAI chat model. model=%s", model_name)
+
+    return ChatOpenAI(model=model_name, temperature=0.3)
+
+
+## ==============================================================================
+## RAG Chain Builder (stateless)
+## ==============================================================================
+def build_rag_chain(provider: str, model_name: str):
     """
     Pinecone Retrieval + LLM Answer 체인을 생성합니다.
 
@@ -201,7 +225,7 @@ def build_rag_chain():
         ]
     )
 
-    llm = ChatOpenAI(model=OPENAI_MODEL, temperature=0.3)
+    llm = _build_llm(provider, model_name)
     retriever = get_retriever()
     parser = StrOutputParser()
 
@@ -221,12 +245,12 @@ def build_rag_chain():
         span("prompt_build", t, docs=len(docs), chars_context=len(context))
 
         # 3) LLM answer with forced citation format
-        mark("llm_start", model=OPENAI_MODEL)
+        mark("llm_start", provider=provider, model=model_name)
         t = now()
         raw = llm.invoke(msg)
-        span("llm_total", t, model=OPENAI_MODEL)
-        answer = parser.invoke(raw).strip()
+        span("llm_total", t, provider=provider, model=model_name)
 
+        answer = parser.invoke(raw).strip()
         return {"answer": answer, "sources": sources}
 
     return _invoke

--- a/backend/app/service/llm_service.py
+++ b/backend/app/service/llm_service.py
@@ -1,3 +1,4 @@
+import hashlib
 import uuid
 from functools import lru_cache
 from typing import Optional, Any
@@ -5,7 +6,12 @@ from typing import Optional, Any
 # from requests import Session
 from sqlalchemy.orm import Session
 
-from app.core.config import OPENAI_MODEL
+from app.core.config import (
+    OPENAI_MODEL,
+    LLM_PROVIDER_MODE,
+    LLM_AB_RATIO,
+    BEDROCK_MODEL_ID,
+    )
 from app.core.logger import get_logger
 from app.core.metrics import now, span
 from app.repository.chat import list_messages
@@ -14,10 +20,40 @@ from app.service.chain_builder import build_rag_chain
 logger = get_logger("chatbot-law-prod.llm")
 
 
-@lru_cache(maxsize=1)
-def get_chain():
-    logger.info("Initializing RAG chain (cached).")
-    return build_rag_chain()
+def select_provider(session_id: str) -> str:
+    """
+    provider 선택:
+    - openai: OpenAI만 사용
+    - bedrock: Bedrock만 사용
+    - ab: session_id 해시 기반 50:50(or ration) 분기
+    """
+    mode = LLM_PROVIDER_MODE
+
+    if mode in ("openai", "bedrock"):
+        return mode
+    
+    if mode == "ab":
+        digest = hashlib.md5(session_id.encode("utf-8")).hexdigest()
+        bucket = int(digest, 16) % 100
+        return "openai" if bucket < LLM_AB_RATIO else "bedrock"
+    
+    ## fallback
+    return "openai"
+
+
+def get_model_name(provider: str) -> str:
+    if provider == "bedrock":
+        return BEDROCK_MODEL_ID
+    return OPENAI_MODEL
+
+@lru_cache(maxsize=8)
+def get_chain(provider: str, model_name: str):
+    logger.info(
+        "Initializing RAG chain (cached). provider=%s, model=%s",
+        provider,
+        model_name,
+    )
+    return build_rag_chain(provider=provider, model_name=model_name)
 
 
 def ask_llm(db: Session, message: str, session_id: Optional[str] = None):
@@ -29,9 +65,12 @@ def ask_llm(db: Session, message: str, session_id: Optional[str] = None):
         session_id = str(uuid.uuid4())
         logger.info("Generated new session_id=%s", session_id)
 
+    provider = select_provider(session_id)
+    model_name = get_model_name(provider)
+
     HISTORY_LIMIT = 20
 
-    # 1. 대화 기록 로드 (최대 HISTORY_LIMIT개)
+    ## 1. 대화 기록 로드 (최대 HISTORY_LIMIT개)
     t = now()
     history = list_messages(db, session_id, limit=HISTORY_LIMIT)
     ms_history_load = span("db_history_load", t, limit=HISTORY_LIMIT)
@@ -47,15 +86,17 @@ def ask_llm(db: Session, message: str, session_id: Optional[str] = None):
             else message
         )
 
-    chain = get_chain()
+    chain = get_chain(provider, model_name)
     result = chain({"input": input_text})  # invoke와 동일하게 동작
 
     answer = (result.get("answer") or "").strip()
     sources = result.get("sources") or []
 
     logger.info(
-        "ask_llm completed. session_id=%s, answer_len=%d, sources=%d",
+        "ask_llm completed. session_id=%s, model=%s, model_name=%s, answer_len=%d, sources=%d",
         session_id,
+        provider,
+        model_name,
         len(answer),
         len(sources),
     )
@@ -63,8 +104,8 @@ def ask_llm(db: Session, message: str, session_id: Optional[str] = None):
     ## A/B를 위한 최소 메타
     extra: dict[str, Any] = {
         "ms_history_load": ms_history_load,
-        "provider": "openai",
-        "model": OPENAI_MODEL,
+        "provider": provider,
+        "model": model_name,
     }
 
     return answer, session_id, sources, extra


### PR DESCRIPTION
## 개요 (Overview)

이 PR에서는 LLM 실행 구조를 리팩토링하여 OpenAI뿐 아니라 Amazon Bedrock을 함께 사용할 수 있도록 **LLM Provider 추상화 구조**를 도입했습니다.

환경 변수 설정을 통해 실행 시점에 사용할 LLM Provider를 선택할 수 있으며, 세션 기반으로 OpenAI와 Bedrock을 분기하는 **A/B 실험 라우팅 기능**을 추가했습니다.

이를 통해 RAG 파이프라인에서 다음과 같은 비교 실험이 가능해집니다.

- OpenAI vs Bedrock 응답 품질 비교
- LLM 응답 지연시간(Latency) 비교
- 모델 비용 최적화 전략 수립

본 변경은 향후 **멀티 LLM 아키텍처 운영을 위한 기반 구조**를 마련하기 위한 작업입니다.


---

## 주요 변경 사항 (Key Changes)

### 1. LLM Provider 추상화 구조 도입

LLM 호출 구조를 다음과 같이 리팩토링했습니다.

llm_service
→ provider 선택
→ chain_builder
→ OpenAI 또는 Bedrock 호출


환경 변수 설정을 통해 실행 시 사용할 LLM Provider를 동적으로 결정할 수 있습니다.


---

### 2. Amazon Bedrock 모델 지원 추가

`langchain_aws`를 사용하여 Bedrock Chat Model을 사용할 수 있도록 지원을 추가했습니다.

사용 가능한 모델 예시:
anthropic.claude-3-haiku-20240307-v1:0


Bedrock 관련 설정은 환경 변수로 제어됩니다.


---

### 3. 세션 기반 LLM A/B 라우팅 구현

세션 ID 기반의 **deterministic routing**을 구현하여 OpenAI와 Bedrock 간 A/B 실험이 가능하도록 했습니다.

동작 방식은 다음과 같습니다.

LLM_PROVIDER_MODE=openai → OpenAI만 사용
LLM_PROVIDER_MODE=bedrock → Bedrock만 사용
LLM_PROVIDER_MODE=ab → 세션 기반 A/B 라우팅


A/B 분기 비율은 다음 환경 변수로 제어됩니다.
LLM_AB_RATIO




---

### 4. LLM 성능 관측을 위한 로그 확장

LLM 호출 관련 로그에 **provider와 model 정보를 추가**했습니다.

예시 로그:
METRIC|event=llm_start|provider=openai|model=gpt-4o-mini
METRIC|event=llm_total|provider=bedrock|model=claude-3-haiku
METRIC|event=request|provider=openai|model=gpt-4o-mini



이를 통해 다음 항목을 직접 비교할 수 있습니다.

- 모델 응답 지연시간
- Retrieval + Generation 시간
- Provider별 성능 차이


---

## 환경 변수 (Environment Variables)

새로 추가된 환경 변수는 다음과 같습니다.

LLM_PROVIDER_MODE=openai | bedrock | ab
LLM_AB_RATIO=50
BEDROCK_REGION=us-east-1
BEDROCK_MODEL_ID=anthropic.claude-3-haiku-20240307-v1:0



---

## 테스트 (Testing)

### 로컬 환경 (OpenAI 모드)
LLM_PROVIDER_MODE=openai


확인 사항

- RAG Retrieval 정상 동작
- OpenAI 응답 생성 정상
- LLM 관련 METRIC 로그 정상 출력


---

### 로컬 환경 (Bedrock 모드)
LLM_PROVIDER_MODE=bedrock



Provider 분기 로직은 정상 동작함을 확인했습니다.

로컬 환경에서는 AWS 인증 토큰이 유효하지 않아 Bedrock 호출이 실패했으며, 이는 로컬 환경 인증 설정에 따른 정상적인 동작입니다.


---

### Dev 환경

Elastic Beanstalk에 다음 환경 변수를 추가했습니다.

LLM_PROVIDER_MODE=ab
LLM_AB_RATIO=50
BEDROCK_REGION=us-east-1
BEDROCK_MODEL_ID=anthropic.claude-3-haiku-20240307-v1:0


Dev 환경에서 다음 항목을 검증할 예정입니다.

- Bedrock 모델 정상 호출 여부
- OpenAI / Bedrock A/B 분기 동작 확인
- Provider별 응답 지연시간 비교


---

## 기대 효과 (Impact)

이번 변경을 통해 다음과 같은 구조를 갖추게 됩니다.

LLM Execution Layer
│
├─ OpenAI
└─ Bedrock
│
└─ Session 기반 A/B 실험



이를 통해 다음과 같은 운영 전략을 적용할 수 있습니다.

- 멀티 LLM Provider 아키텍처
- 모델 성능 비교 실험
- 비용 최적화 전략
- 서비스 안정성을 위한 LLM 분산 구조

기존 RAG 파이프라인(Pinecone Retrieval)은 변경 없이 그대로 유지됩니다.















